### PR TITLE
chore: configure .gitattributes for correct GitHub language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Ignore Flutter default platform code
+android/* linguist-vendored
+ios/* linguist-vendored
+macos/* linguist-vendored
+linux/* linguist-vendored
+windows/* linguist-vendored
+web/* linguist-vendored
+
+# Ensure Dart is correctly recognized
+*.dart linguist-language=Dart
+


### PR DESCRIPTION
add .gitattributes to ignore Flutter platform code and ensure Dart recognition